### PR TITLE
Replace legacy MyISAM database engines with InnoDB

### DIFF
--- a/siremis/modules/contact/mod.install.sql
+++ b/siremis/modules/contact/mod.install.sql
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS `contact` (
   `update_time` timestamp NOT NULL DEFAULT '2000-01-01 00:00:00' ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `type_id` (`type_id`)
-) ENGINE=MyISAM  DEFAULT CHARSET=utf8 AUTO_INCREMENT=5 ;
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=5 ;
 
 
 INSERT INTO `contact` (`id`, `first_name`, `last_name`, `display_name`, `company`, `department`, `position`, `fast_index`, `photo`, `phone`, `mobile`, `fax`, `zipcode`, `province`, `city`, `street`, `country`, `email`, `webpage`, `qq`, `icq`, `skype`, `yahoo`, `misc`, `type_id`, `sortorder`, `user_id`, `published`, `default`, `access`, `params`, `create_by`, `create_time`, `update_by`, `update_time`) VALUES
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS `contact_type` (
   `update_by` int(11) NOT NULL,
   `update_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM  DEFAULT CHARSET=utf8 AUTO_INCREMENT=5 ;
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 AUTO_INCREMENT=5 ;
 
 
 INSERT INTO `contact_type` (`id`, `name`, `description`, `sortorder`, `published`, `create_by`, `create_time`, `update_by`, `update_time`) VALUES

--- a/siremis/modules/cronjob/mod.install.sql
+++ b/siremis/modules/cronjob/mod.install.sql
@@ -27,6 +27,6 @@ CREATE TABLE `cronjob` (
   KEY `weekday` (`day`),
   KEY `month` (`month`),
   KEY `week` (`weekday`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `cronjob` */

--- a/siremis/modules/eventlog/mod.install.sql
+++ b/siremis/modules/eventlog/mod.install.sql
@@ -13,5 +13,5 @@ CREATE TABLE `event_log` (
      PRIMARY KEY  (`id`),                                                                                                                        
      KEY `UserID` (`user_id`,`ipaddr`,`event`),                                                                                                  
      KEY `Message` (`message`)                                                                                                                   
-   ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+   ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/siremis/modules/help/mod.install.sql
+++ b/siremis/modules/help/mod.install.sql
@@ -16,7 +16,7 @@ CREATE TABLE `help` (
   PRIMARY KEY  (`id`),
   KEY `create_by` (`create_by`),
   KEY `update_by` (`update_by`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `help` */
 
@@ -47,7 +47,7 @@ CREATE TABLE `help_category` (
   `update_time` datetime NOT NULL,
   PRIMARY KEY  (`id`),
   KEY `parent_id` (`parent_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `help_category` */
 
@@ -71,6 +71,6 @@ CREATE TABLE `help_category_mapping` (
   PRIMARY KEY  (`id`),
   KEY `url` (`url`),
   KEY `cat_id` (`cat_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `help_category_mapping` */

--- a/siremis/modules/system/mod.install.sql
+++ b/siremis/modules/system/mod.install.sql
@@ -9,7 +9,7 @@ CREATE TABLE `acl_action` (
   `action` varchar(64) NOT NULL default '',
   `description` varchar(255) default NULL,
   PRIMARY KEY  (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Table structure for table `acl_role_action` */
 
@@ -23,7 +23,7 @@ CREATE TABLE `acl_role_action` (
   PRIMARY KEY  (`id`),
   KEY `role_id` (`role_id`),
   KEY `action_id` (`action_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Table structure for table `meta_do` */
 
@@ -38,7 +38,7 @@ CREATE TABLE `meta_do` (
   `data` text,
   `fields` text,
   PRIMARY KEY  (`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Table structure for table `meta_form` */
 
@@ -53,7 +53,7 @@ CREATE TABLE `meta_form` (
   `data` text,
   `elements` text,
   PRIMARY KEY  (`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Table structure for table `meta_view` */
 
@@ -67,7 +67,7 @@ CREATE TABLE `meta_view` (
   `data` text,
   `forms` text,
   PRIMARY KEY  (`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Table structure for table `module` */
 
@@ -84,7 +84,7 @@ CREATE TABLE `module` (
   `depend_on` varchar(255) default NULL,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Table structure for table `role` */
 
@@ -101,7 +101,7 @@ CREATE TABLE `role` (
   UNIQUE KEY `name` (`name`),
   INDEX (  `default` ),
   INDEX (  `status` )
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `role` */
 
@@ -129,7 +129,7 @@ CREATE TABLE `user` (
   PRIMARY KEY  (`id`),
   UNIQUE KEY `username` (`username`),
   KEY `email` (`email`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `user` */
 
@@ -148,7 +148,7 @@ CREATE TABLE `user_role` (
   PRIMARY KEY  (`id`),
   KEY `user_id` (`user_id`),
   KEY `role_id` (`role_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Data for the table `user_role` */
 
@@ -166,7 +166,7 @@ CREATE TABLE `group` (
   `description` varchar(255) default NULL,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*Table structure for table `group_role` */
 
@@ -179,7 +179,7 @@ CREATE TABLE `user_group` (
   PRIMARY KEY  (`id`),
   KEY `user_id` (`user_id`),
   KEY `group_id` (`group_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 DROP TABLE IF EXISTS `pass_token`;
@@ -191,7 +191,7 @@ CREATE TABLE IF NOT EXISTS `pass_token` (
   `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `token` (`token`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;
 
 /*Table structure for table `menu` */
 
@@ -217,7 +217,7 @@ CREATE TABLE `menu` (
   `update_by` int(10) default 1,
   `update_time` datetime default NULL,
   PRIMARY KEY  (`name`)                         
-) ENGINE=MyISAM DEFAULT CHARSET=utf8   
+) ENGINE=InnoDB DEFAULT CHARSET=utf8   
   
 /*Data for the table `menu` */
 


### PR DESCRIPTION
Having the database definition use MyISAM means that strange and odd things will happen
when trying to use siremis with a clustered database, as only InnoDB clusters 'correctly'.

There aren't any issues switching engines, as long as the user is using MySQL 5.4 or higher, and anyone who's doing a new install now SHOULD be! (There are performance issues with InnoDB on 5.3 and lower)

Signed-Off-By: Rob Thomas <xrobau@gmail.com>